### PR TITLE
Pull correct bytes for seconds/milliseconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,8 +76,8 @@ async function getNetworkTime({
     );
 
   // thats inspired by https://github.com/Grassboy/NTPServer/blob/master/timeserver.node.js
-  const intpart = msg.readUInt32BE(msg.length - 16);
-  const fractpart = msg.readUInt32BE(msg.length - 8);
+  const intpart = msg.readUInt32BE(msg.length - 8);
+  const fractpart = msg.readUInt32BE(msg.length - 4);
   const milliseconds = intpart * 1000 + (fractpart * 1000) / 0x100000000;
 
   // **UTC** time


### PR DESCRIPTION
Code was pulling 32-bit values that ended up being the exact same number every time due to the format of the NTP message.

Change the offsets to get correct value for milliseconds being returned from the server.